### PR TITLE
feat: enable cron-integration

### DIFF
--- a/src/Plugin/QueueWorker/Converterqueue.php
+++ b/src/Plugin/QueueWorker/Converterqueue.php
@@ -16,7 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 #[QueueWorker(
   id: 'responsive_video_converterqueue',
-  title: new TranslatableMarkup('ConverterQueue'),
+  title: new TranslatableMarkup('ConverterQueue'),  
+  cron: ['time' => 300]  
 )]
 final class Converterqueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 

--- a/src/Plugin/QueueWorker/Converterqueue.php
+++ b/src/Plugin/QueueWorker/Converterqueue.php
@@ -16,8 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 #[QueueWorker(
   id: 'responsive_video_converterqueue',
-  title: new TranslatableMarkup('ConverterQueue'),  
-  cron: ['time' => 300]  
+  title: new TranslatableMarkup('ConverterQueue'),
+  cron: ['time' => 300]
 )]
 final class Converterqueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 


### PR DESCRIPTION
although this documentation says otherwise:

https://www.drupal.org/node/3344220

I tested and the loaded plugin definition comes with cron = null

which then causes the worker plugin to be excluded from normal crons runs


300 secs = 5 minutes (talked with @tobias-hu quickly about a common sense value for this)